### PR TITLE
Accept zero padding in rem

### DIFF
--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -131,26 +131,41 @@ test('toggle click calls onClick argument with isExpanded', () => {
   expect(onClick).toHaveBeenCalled()
 })
 
-test('warns if using padding on collapse', () => {
-  // Mocking console.warn so it does not log to the console,
-  // but we can still intercept the message
+describe('padding on collapse', () => {
   const originalWarn = console.warn
-  let consoleOutput = ''
-  const mockWarn = (output: any) => (consoleOutput = output)
-  console.warn = jest.fn(mockWarn)
+  let consoleOutput: string[] = []
+  const mockWarn = (output: any) => consoleOutput.push(output)
+  const { rerender } = render(<Collapse />)
 
-  render(
-    <Collapse
-      props={{ defaultExpanded: true }}
-      collapseProps={{ style: { padding: 20 } }}
-    />
-  )
+  beforeEach(() => (console.warn = mockWarn))
+  afterEach(() => {
+    console.warn = originalWarn
+    consoleOutput = []
+  })
 
-  expect(consoleOutput).toMatchInlineSnapshot(
-    `"Warning: react-collapsed: Padding applied to the collapse element will cause the animation to break and not perform as expected. To fix, apply equivalent padding to the direct descendent of the collapse element."`
-  )
+  it('warns if using padding on collapse', () => {
+    rerender(
+      <Collapse
+        props={{ defaultExpanded: true }}
+        collapseProps={{ style: { padding: 20 } }}
+      />
+    )
 
-  console.warn = originalWarn
+    expect(consoleOutput[0]).toMatchInlineSnapshot(
+      `"Warning: react-collapsed: Padding applied to the collapse element will cause the animation to break and not perform as expected. To fix, apply equivalent padding to the direct descendent of the collapse element."`
+    )
+  })
+
+  it('doesn`t warn if padding is 0 but in rem', () => {
+    rerender(
+      <Collapse
+        props={{ defaultExpanded: true }}
+        collapseProps={{ style: { padding: '0rem' } }}
+      />
+    )
+
+    expect(consoleOutput.length).toBe(0)
+  })
 })
 
 test('permits access to the collapse ref', () => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -190,8 +190,8 @@ export function usePaddingWarning(element: RefObject<HTMLElement>): void {
       }
       const { paddingTop, paddingBottom } = window.getComputedStyle(el.current)
       const hasPadding =
-        (paddingTop && paddingTop !== '0px') ||
-        (paddingBottom && paddingBottom !== '0px')
+        (paddingTop && paddingTop !== '0px' && paddingTop !== '0rem') ||
+        (paddingBottom && paddingBottom !== '0px' && paddingTop !== '0rem')
 
       warning(
         !hasPadding,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -191,7 +191,7 @@ export function usePaddingWarning(element: RefObject<HTMLElement>): void {
       const { paddingTop, paddingBottom } = window.getComputedStyle(el.current)
       const hasPadding =
         (paddingTop && paddingTop !== '0px' && paddingTop !== '0rem') ||
-        (paddingBottom && paddingBottom !== '0px' && paddingTop !== '0rem')
+        (paddingBottom && paddingBottom !== '0px' && paddingBottom !== '0rem')
 
       warning(
         !hasPadding,


### PR DESCRIPTION
The way the code is written today makes the warning appear if you have a div with `paddingTop: 0rem` as if you were using a valued padding, this contribution seeks to fix that.


You can reproduce the problem by simply changing the prop on your old test from 
`padding: 20` to `padding: 0rem`
