### PR TITLE
Add aria-labelledby

### DIFF
--- a/.changeset/tricky-feet-cheat.md
+++ b/.changeset/tricky-feet-cheat.md
@@ -1,0 +1,5 @@
+---
+'react-collapsed': patch
+---
+
+Added `aria-labelledby` to the collapse panel, to be labelled by the toggle.

--- a/packages/react-collapsed/src/index.ts
+++ b/packages/react-collapsed/src/index.ts
@@ -314,6 +314,7 @@ export function useCollapse({
       return {
         id: `react-collapsed-panel-${uniqueId}`,
         'aria-hidden': !isExpanded,
+        'aria-labelledby': `react-collapsed-toggle-${uniqueId}`,
         role: 'region',
         ...args,
         [refKey || 'ref']: mergeRefs(collapseElRef, theirRef),

--- a/packages/react-collapsed/tests/index.test.tsx
+++ b/packages/react-collapsed/tests/index.test.tsx
@@ -143,3 +143,8 @@ test('id will be overridden by prop getters', () => {
   expect(container.querySelector('#baz')).toBeInTheDocument()
   expect(container.querySelector('#bar')).toBeInTheDocument()
 })
+
+test('collapse element labelled by toggle', () => {
+  render(<Collapse />)
+  expect(screen.getByLabelText('Toggle')).toEqual(screen.getByTestId('collapse'))
+})


### PR DESCRIPTION
Missing the recommended `aria-labelledby` attribute according to https://www.w3.org/WAI/ARIA/apg/patterns/accordion/

> Optionally, each element that serves as a container for panel content has role [region](https://w3c.github.io/aria/#region) and [aria-labelledby](https://w3c.github.io/aria/#aria-labelledby) with a value that refers to the button that controls display of the panel.